### PR TITLE
Things added after 6/19 session

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ function App() {
     <div className="font-sans font-bold bg-vdk-desat-blu-main p-10">
       <div className="top-row flex justify-between items-center">
         <h1>calc</h1>
-        <div className="theme-container flex basis-2/5 justify-between items-center">
+        <div className="theme-container flex basis-2/5 justify-between items-end">
           <div>THEME</div>
           <div className="toggle-container flex">
             <div className="toggle-position flex flex-col pr-1 items-center">
@@ -25,27 +25,27 @@ function App() {
         </div>
       </div>
       <div className="calculator-container">
-        <div className="screen bg-vdk-desat-blu-screen text-numbers text-right rounded-lg my-6 py-4 pr-6">Test</div>
+        <div className="screen bg-vdk-desat-blu-screen text-right text-numbers rounded-lg my-6 py-4 pr-6">Test</div>
         <div className="numpad-container bg-vdk-desat-blu-inset p-6 rounded-lg">
-          <div className="numpad-row flex mb-2">
+          <div className="numpad-row flex mb-3">
             <NumberKey value="7" />
             <NumberKey value="8" />
             <NumberKey value="9" />
             <NumberKey value="DEL" />
           </div>
-          <div className="numpad-row flex mb-2">
+          <div className="numpad-row flex mb-3">
             <NumberKey value="4" />
             <NumberKey value="5" />
             <NumberKey value="6" />
             <NumberKey value="+" />
           </div>
-          <div className="numpad-row flex mb-2">
+          <div className="numpad-row flex mb-3">
             <NumberKey value="1" />
             <NumberKey value="2" />
             <NumberKey value="3" />
             <NumberKey value="-" />
           </div>
-          <div className="numpad-row flex mb-2">
+          <div className="numpad-row flex mb-3">
             <NumberKey value="." />
             <NumberKey value="0" />
             <NumberKey value="/" />

--- a/src/components/NumberKey.tsx
+++ b/src/components/NumberKey.tsx
@@ -1,25 +1,27 @@
+// TODO - look into 'ctnl' package to wrangle tailwind class name list
+
 type NumberKeyProps = {
   value: string,
 }
 
-enum KeyColors {
-  MainBG = 'bg-thm1-main-key-bg text-thm1-main-key-txt border-thm1-main-key-shadow',
-  SecondaryBG = 'bg-thm1-secondary-key-bg border-thm1-secondary-key-shadow',
-  TertiaryBG = 'bg-thm1-tertiary-key-bg border-thm1-tertiary-key-shadow'
+enum KeyClassNames {
+  Main = 'bg-thm1-main-key-bg text-thm1-main-key-txt border-thm1-main-key-shadow text-numbers',
+  Secondary = 'bg-thm1-secondary-key-bg border-thm1-secondary-key-shadow text-lg py-3',
+  Tertiary = 'bg-thm1-tertiary-key-bg border-thm1-tertiary-key-shadow text-lg py-3'
 }
 
 const getKeyColors = (value: string) => {
-  if (value === '=') return KeyColors.TertiaryBG
-  if (value === 'DEL' || value === 'RESET') return KeyColors.SecondaryBG
+  if (value === '=') return KeyClassNames.Tertiary
+  if (value === 'DEL' || value === 'RESET') return KeyClassNames.Secondary
 
-  return KeyColors.MainBG
+  return KeyClassNames.Main
 }
 
 export const NumberKey = ({ value }: NumberKeyProps) => {
 
   
   return (
-    <div className={`number-key grow basis-1/4 ${getKeyColors(value)} border-b-4 rounded-lg text-center py-4 mx-1`}>
+    <div className={`number-key grow position-relative basis-1/4 ${getKeyColors(value)} border-b-4 rounded-lg text-center mx-2 active:opacity-80 active:border-b-0 active:mt-1 hover:cursor-pointer`}>
       {value}
     </div>
   )


### PR DESCRIPTION
## Description
* Renamed `KeyColors` enum to `KeyClassNames`.
  * renamed enum keys to `Main`, `Secondary`, and `Tertiary`.
* Changed `.theme-container` to be `items-end` instead of `items-center` to have the word 'THEME' align with the slider.
* Increased margin bottom on `numpad-row`s from 2 to 3
* Added active states for numpad keys
  * made active state darken keys, but design has it lighten them, just need to find right color

### To-Do:
* Still need to get proper alignment of numbers/text on keys
* Look into `cntl` package for managing crazy-long tailwind class names: https://www.npmjs.com/package/cntl

@madi-fuller 